### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/eblkygroup/ee698b1d-c10f-4486-ae10-b02ab419bc2e/8ee93435-17a0-4c86-8f88-847dc52e1813/_apis/work/boardbadge/0a774f1c-aa60-4eec-9c98-83d11495efa1)](https://dev.azure.com/eblkygroup/ee698b1d-c10f-4486-ae10-b02ab419bc2e/_boards/board/t/8ee93435-17a0-4c86-8f88-847dc52e1813/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/eblkygroup/ee698b1d-c10f-4486-ae10-b02ab419bc2e/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.